### PR TITLE
Fix link format and prompt for description

### DIFF
--- a/org-mpv-notes.el
+++ b/org-mpv-notes.el
@@ -225,8 +225,10 @@ the file to proper location and insert a link to that file."
          (h (floor (/ time 3600)))
          (m (floor (/ (mod time 3600) 60)))
          (s (floor (mod time 60)))
-         (timestamp (format "%s:%s:%s" h m s)))
-    (insert "[[" path "::" timestamp "][" timestamp "]]")))
+         (timestamp (format "%02d:%02d:%02d" h m s))
+		 (name (read-string "Description: ")))
+    (insert "[[mpv:" path "::" timestamp "][" name "]]")))
+
 
 (defun org-mpv-notes-replace-timestamp-with-link (link)
   (interactive "sLink:")


### PR DESCRIPTION
I changed the link format to appear as
[[mpv:pth-to-video::hh:mm:dd][description]]
as it is required by `mpv-seek-to-position-at-point`.

For example a link with timestamp 0:1:22 would not work, but 0:01:22 would work.

See the regexp in [mpv.el](https://github.com/kljohann/mpv.el/blob/2e0234bc21a3dcdf12d94d3285475e7f6769d3e8/mpv.el#L598)