### PR TITLE
Support MELPA package empv.el

### DIFF
--- a/org-mpv-notes.el
+++ b/org-mpv-notes.el
@@ -6,7 +6,7 @@
 ;; Maintainer: Bibek Panthi <bpanthi977@gmail.com>
 ;; URL: https://github.com/bpanthi977/org-mpv-notes
 ;; Version: 0.0.1
-;; Package-Requires: ((emacs "27.1") (mpv "0.2.0"))
+;; Package-Requires: ((emacs "27.1"))
 ;; Kewords: mpv, org
 
 ;; This file in not part of GNU Emacs

--- a/org-mpv-notes.el
+++ b/org-mpv-notes.el
@@ -25,7 +25,8 @@
 
 ;;; Code:
 (require 'cl-lib)
-(require 'mpv)
+(require 'mpv nil 'noerror)
+(require 'empv nil 'noerror)
 (require 'org-attach)
 (require 'org-element)
 

--- a/org-mpv-notes.el
+++ b/org-mpv-notes.el
@@ -114,9 +114,9 @@ ARG is passed to `org-link-complete-file'."
   (cl-multiple-value-bind (path secs) (org-mpv-notes--parse-link path)
     ;; Enable Minor mode
     (org-mpv-notes t)
-    (let ((backend (or (find 'mpv features)
-                       (find 'empv features))))
-      (flet ((alive? ()
+    (let ((backend (or (cl-find 'mpv features)
+                       (cl-find 'empv features))))
+      (cl-flet ((alive? ()
                      (if (eql backend 'mpv)
                          (mpv-live-p)
                        (empv--running?)))

--- a/org-mpv-notes.el
+++ b/org-mpv-notes.el
@@ -137,7 +137,9 @@ ARG is passed to `org-link-complete-file'."
 
         ;; Open mpv player
         (cond ((not (alive?))
-               (start path))
+               (start path)
+               (sleep-for 0.05)
+               (seek path))
               ((not (string-equal (org-mpv-notes--get-property "path") path))
                (kill)
                (sleep-for 0.05)

--- a/org-mpv-notes.el
+++ b/org-mpv-notes.el
@@ -110,7 +110,6 @@ ARG is passed to `org-link-complete-file'."
 (defun org-mpv-notes-open (path &optional arg)
   "Open the mpv `PATH'.
 `ARG' is required by org-follow-link but is ignored here."
-  ;; TODO: Support for empv.el
   (cl-multiple-value-bind (path secs) (org-mpv-notes--parse-link path)
     ;; Enable Minor mode
     (org-mpv-notes t)


### PR DESCRIPTION
+ Check which of TWO Emacs mpv interfaces are loaded and active, and
  uses that one to get data for creating org-links and notes.

+ Report errors for 'no backend package loaded' and 'no data received
  from the backend'