### PR TITLE
Don't create a note until all link data is obtained

### DIFF
--- a/org-mpv-notes.el
+++ b/org-mpv-notes.el
@@ -261,10 +261,12 @@ If `READ-DESCRIPTION' is true, ask for a link description from user."
 (defun org-mpv-notes-insert-note ()
   "Insert a heading with link & timestamp."
   (interactive)
-  (org-insert-heading)
-  (save-excursion
-    (org-insert-property-drawer)
-    (org-set-property "mpv_link" (org-mpv-notes--create-link nil))))
+  (let ((link  (org-mpv-notes--create-link nil)))
+    (when link
+      (org-insert-heading)
+      (save-excursion
+        (org-insert-property-drawer)
+        (org-set-property "mpv_link" link)))))
 
 (defun org-mpv-notes-insert-link ()
   "Insert link with timestamp."


### PR DESCRIPTION
+ Fixes bug for cases we fail to create a link. Prior behavior was
  that the function would abort, leaving the user with a partially
  created note.