### PR TITLE
Navigate timestamps properly

### DIFF
--- a/org-mpv-notes.el
+++ b/org-mpv-notes.el
@@ -314,9 +314,7 @@ If `READ-DESCRIPTION' is true, ask for a link description from user."
   (let ((link  (org-mpv-notes--create-link nil)))
     (when link
       (org-insert-heading)
-      (save-excursion
-        (org-insert-property-drawer)
-        (org-set-property "mpv_link" link)))))
+      (insert link))))
 
 (defun org-mpv-notes-insert-link ()
   "Insert link with timestamp."

--- a/org-mpv-notes.el
+++ b/org-mpv-notes.el
@@ -170,12 +170,16 @@ the file to proper location and insert a link to that file."
 
 (defvar org-mpv-notes-link-regex "\\[\\[mpv:\\([^\\n\\]*?\\)\\]\\[\\([^\\n]*?\\)\\]\\]")
 
+(defun org-mpv-notes-timestamp-p ()
+  "Return non-NIL if POINT is on a timestamp."
+ (string-match "mpv" (or (org-element-property :type (org-element-context)) "")))
+
 (defun org-mpv-notes-next-timestamp (&optional reverse)
   "Seek to next timestamp in the notes file."
   (interactive)
   (let (success)
     (while (and (not success) (org-next-link reverse))
-      (when (string-match "mpv" (or (org-element-property :type (org-element-context)) ""))
+      (when (org-mpv-notes-timestamp-p)
         (setq success t)))
     (if (not success)
       (error "Error: No %s link" (if reverse "prior" "next"))
@@ -194,7 +198,7 @@ If there is no timestamp at POINT, consider the previous one as
 'this' one."
   (interactive)
   (cond
-   ((string-match "mpv" (or (org-element-property :type (org-element-context)) ""))
+   ((org-mpv-notes-timestamp-p)
      (org-mpv-notes-open path)
      (org-show-entry)
      (recenter))

--- a/org-mpv-notes.el
+++ b/org-mpv-notes.el
@@ -170,23 +170,23 @@ the file to proper location and insert a link to that file."
 
 (defvar org-mpv-notes-link-regex "\\[\\[mpv:\\([^\\n\\]*?\\)\\]\\[\\([^\\n]*?\\)\\]\\]")
 
-(defun org-mpv-notes-next-timestamp ()
+(defun org-mpv-notes-next-timestamp (&optional reverse)
   "Seek to next timestamp in the notes file."
   (interactive)
-  (when (re-search-forward org-mpv-notes-link-regex nil t)
-    (backward-char)
-    (org-open-at-point)
-    (org-show-entry)
-    (recenter)))
+  (let (success)
+    (while (and (not success) (org-next-link reverse))
+      (when (string-match "mpv" (or (org-element-property :type (org-element-context)) ""))
+        (setq success t)))
+    (if (not success)
+      (error "Error: No %s link" (if reverse "prior" "next"))
+     (org-open-at-point)
+     (org-show-entry)
+     (recenter))))
 
 (defun org-mpv-notes-previous-timestamp ()
   "Seek to previous timestamp in the notes file."
   (interactive)
-  (when (re-search-backward org-mpv-notes-link-regex nil t)
-    (forward-char)
-    (org-open-at-point)
-    (org-show-entry)
-    (recenter)))
+  (org-mpv-notes-next-timestamp t))
 
 (defun org-mpv-notes-this-timestamp ()
   "Seeks to the timestamp at point or stored in the property drawer of the heading."

--- a/org-mpv-notes.el
+++ b/org-mpv-notes.el
@@ -217,7 +217,7 @@ If there is no timestamp at POINT, consider the previous one as
   (interactive)
   (cond
    ((org-mpv-notes-timestamp-p)
-     (org-mpv-notes-open path)
+     (org-mpv-notes-open (org-element-property :path (org-element-context)))
      (org-show-entry)
      (recenter))
    (t

--- a/org-mpv-notes.el
+++ b/org-mpv-notes.el
@@ -189,20 +189,17 @@ the file to proper location and insert a link to that file."
   (org-mpv-notes-next-timestamp t))
 
 (defun org-mpv-notes-this-timestamp ()
-  "Seeks to the timestamp at point or stored in the property drawer of the heading."
+  "Seek to the timestamp at POINT or previous.
+If there is no timestamp at POINT, consider the previous one as
+'this' one."
   (interactive)
-  (let* ((element (org-element-context))
-         (path (and element
-                    (eql (org-element-type element) 'link)
-                    (org-element-property :path element))))
-    (unless path
-      (let ((raw-link (org-entry-get (point) "mpv_link" t)))
-        (when (and raw-link (string-match org-mpv-notes-link-regex raw-link))
-          (setf path (match-string 1 raw-link)))))
-
-    (org-mpv-notes-open path)
-    (org-show-entry)
-    (recenter)))
+  (cond
+   ((string-match "mpv" (or (org-element-property :type (org-element-context)) ""))
+     (org-mpv-notes-open path)
+     (org-show-entry)
+     (recenter))
+   (t
+     (save-excursion (org-mpv-notes-previous-timestamp)))))
 
 ;;;;;
 ;;; MPV Controls


### PR DESCRIPTION
+ This commit seems to fix issues #10 and #11

  #10: Functions org-mpv-notes-{next,previous}-timestamp fail when
  POINT is within the link.

  #11: When the next/previous timestamp is within a property drawer,
  functions org-mpv-notes-{next,previous}-timestamp move point to that
  location.

+ Use pre-existing org-mode features and functions to naviagte mpv links

+ This commit might not be a complete fix for issue #11 in that it
  follows the org-mode convention that the contents of property
  drawers are not considered links, so they are totally ignored and
  POINT is not moved at all from the prior position.

  In order to keep this package consistent with org-mode standards,
  the feature of having an actionable timestamp within a property
  drawer should be re-evaluated.

  My suggestion is:

  1) Redefine the note creation process so that the timestamp is the
  start of a first paragraph after the note heading.

  2) Remove the mpv property from the properties drawer. Since this is
  currently the only reason to have the properties drawer, eliminate
  it entirely for this package. Since this makes an org-mpv note just
  another new org-mode header, eliminate the feature to create a new
  note, and operate just with new links.