### PR TITLE
org-mpv-notes-link-regex: support youtube-style file names

### DIFF
--- a/org-mpv-notes.el
+++ b/org-mpv-notes.el
@@ -168,7 +168,8 @@ the file to proper location and insert a link to that file."
 ;;; Motion (jump to next, previous, ... link)
 ;;;;;
 
-(defvar org-mpv-notes-link-regex "\\[\\[mpv:\\([^\\n\\]*?\\)\\]\\[\\([^\\n]*?\\)\\]\\]")
+(defvar org-mpv-notes-link-regex "\\[\\[mpv:\\(\\(?:[^][\\]\\|\\\\\\(?:\\\\\\\\\\)*[][]\\|\\\\+[^][]\\)+\\)]\\(?:\\[\\([^z-a]+?\\)]\\)?]"
+  "A subset of variable `org-bracket-link-regexp', specific for org-mpv-notes.")
 
 (defun org-mpv-notes-next-timestamp ()
   "Seek to next timestamp in the notes file."


### PR DESCRIPTION
+ The regex did not account for the possibility of square brackets
  embedded in a file name.

+ This is accounted for in variable org-bracket-link-regexp, so I used
  that as my basis, and modified it for this package's mpv links.

+ This should close issue #9